### PR TITLE
switch to background load for progress page

### DIFF
--- a/app/Services/VideoManager/VideoService.php
+++ b/app/Services/VideoManager/VideoService.php
@@ -94,6 +94,9 @@ class VideoService implements VideoServiceInterface
             }
         }
 
+        // 按 fav_time 或 created_at 降序排序以保持与 progress 视图一致的展示顺序
+        $query->orderByRaw('COALESCE(fav_time, created_at) DESC');
+
         $stat = [
             'count'      => (clone $query)->count(),
             'downloaded' => (clone $query)->where('video_downloaded_num', '>', 0)->count(),


### PR DESCRIPTION
我有8400+视频，每次加载需要几十秒：
1. 把progress页面改成在后台进行**分页**加载，现在加载只需要1s。

> 不使用滚动加载的原因：分太多页用户手动滚动基本加载不完，如果不能加载完成全部视频，这个页面的分类功能会变得残缺，比如说无法筛选全部的失效视频

<img width="538" height="248" alt="image" src="https://github.com/user-attachments/assets/b0ccfd72-e0b0-4533-9a91-039e84d4d18c" />

