### PR TITLE
[bug fix] unmatch arguments count in UpdateFav.php

### DIFF
--- a/app/Console/Commands/UpdateFav.php
+++ b/app/Console/Commands/UpdateFav.php
@@ -79,7 +79,7 @@ class UpdateFav extends Command
                         Log::info($message, ['favs' => collect($currentFav->pluck('id'))->toArray()]);
                         continue;
                     }
-                    $this->info(sprintf('[%s] update video parts: %s id: %s, count: %s', $video['title'], $video['id'], $count));
+                    $this->info(sprintf('in update video parts: %s id: %s, count: %s', $video['title'], $video['id'], $count));
                     $updateVideoPartsAction->execute($video);
                     $count++;
                 }


### PR DESCRIPTION
```bash
/app # php artisan app:update-fav --update-video-parts=true --update-video-parts-video-id=115452495921787

In UpdateFav.php line 82:
                                     
  5 arguments are required, 4 given  
```
                                     