### PR TITLE
🔧 修复 About 页面加载卡死问题

### DIFF
--- a/app/Http/Controllers/SystemController.php
+++ b/app/Http/Controllers/SystemController.php
@@ -14,4 +14,9 @@ class SystemController extends Controller
     {
         return response()->json($this->systemService->getSystemInfo());
     }
+
+    public function getMediaUsage()
+    {
+        return response()->json($this->systemService->getMediaUsage());
+    }
 }

--- a/app/Services/SystemService.php
+++ b/app/Services/SystemService.php
@@ -2,7 +2,6 @@
 
 namespace App\Services;
 
-use App\Models\Danmaku;
 use App\Models\FavoriteList;
 use App\Models\Video;
 use App\Models\VideoPart;
@@ -14,7 +13,7 @@ class SystemService
 {
     public function getSystemInfo(): array
     {
-        $info = [
+        return [
             'app_version'      => config('app.version'),
             'php_version'      => phpversion(),
             'laravel_version'  => app()->version(),
@@ -27,22 +26,28 @@ class SystemService
                 'favorite_lists' => FavoriteList::count(),
                 'videos'         => Video::count(),
                 'video_parts'    => VideoPart::count(),
-                'danmaku'        => Danmaku::count(),
                 'db_size'        => $this->getDatabaseSize(),
             ],
-            'media_usage'      => [
-                'videos_size' => $this->getMediaSize('videos'),
-                'images_size' => $this->getMediaSize('images'),
-            ],
+            'media_usage'      => null,
         ];
-        return $info;
+    }
+
+    public function getMediaUsage(): array
+    {
+        return [
+            'videos_size' => $this->getMediaSize('videos'),
+            'images_size' => $this->getMediaSize('images'),
+        ];
     }
 
     public function getDatabaseSize(): int
     {
-        // 如果是sqlite
-        if (DB::connection()->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME) == 'sqlite') {
-            return DB::table('sqlite_master')->where('type', 'table')->sum('rootpage') * 1024;
+        $driver = DB::connection()->getPdo()->getAttribute(PDO::ATTR_DRIVER_NAME);
+        if ($driver == 'sqlite') {
+            $path = DB::connection()->getDatabaseName();
+            if ($path && file_exists($path)) {
+                return filesize($path);
+            }
         }
         return 0;
     }

--- a/resources/js/api/system.ts
+++ b/resources/js/api/system.ts
@@ -1,3 +1,7 @@
 export const getSystemInfo = () => {
     return fetch('/api/system/info').then((res) => res.json());
 };
+
+export const getMediaUsage = () => {
+    return fetch('/api/system/media-usage').then((res) => res.json());
+};

--- a/resources/js/pages/About.vue
+++ b/resources/js/pages/About.vue
@@ -159,10 +159,21 @@
               <p>{{ t('about.favoriteLists') }}：{{ systemInfo.database_usage.favorite_lists }} {{ t('about.units.count') }}</p>
               <p>{{ t('about.videos') }}：{{ systemInfo.database_usage.videos }} {{ t('about.units.count') }}</p>
               <p>{{ t('about.videoParts') }}：{{ systemInfo.database_usage.video_parts }} {{ t('about.units.count') }}</p>
-              <p>{{ t('about.danmaku') }}：{{ systemInfo.database_usage.danmaku.toLocaleString() }} {{ t('about.units.danmaku') }}</p>
               <p>{{ t('about.databaseSize') }}：{{ (systemInfo.database_usage.db_size / 1024 / 1024).toFixed(2) }} {{ t('about.units.mb') }}</p>
-              <p>{{ t('about.mediaVideosUsage') }}：{{ systemInfo.media_usage.videos_size }}</p>
-              <p>{{ t('about.mediaImagesUsage') }}：{{ systemInfo.media_usage.images_size }}</p>
+              <template v-if="mediaLoading">
+                <p class="flex items-center gap-2">
+                  {{ t('about.mediaVideosUsage') }}：
+                  <span class="inline-block animate-spin rounded-full h-4 w-4 border-b-2 border-gray-500"></span>
+                </p>
+                <p class="flex items-center gap-2">
+                  {{ t('about.mediaImagesUsage') }}：
+                  <span class="inline-block animate-spin rounded-full h-4 w-4 border-b-2 border-gray-500"></span>
+                </p>
+              </template>
+              <template v-else>
+                <p>{{ t('about.mediaVideosUsage') }}：{{ mediaUsage.videos_size }}</p>
+                <p>{{ t('about.mediaImagesUsage') }}：{{ mediaUsage.images_size }}</p>
+              </template>
             </div>
           </div>
         </div>
@@ -174,7 +185,7 @@
 <script lang="ts" setup>
 import { ref, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { getSystemInfo } from '@/api/system'
+import { getSystemInfo, getMediaUsage as fetchMediaUsage } from '@/api/system'
 
 const { t } = useI18n();
 
@@ -182,7 +193,6 @@ interface DatabaseUsage {
   favorite_lists: number
   videos: number
   video_parts: number
-  danmaku: number
   db_size: number
 }
 
@@ -203,6 +213,11 @@ interface SystemInfo {
 }
 
 const loading = ref(true)
+const mediaLoading = ref(true)
+const mediaUsage = ref<MediaUsage>({
+  videos_size: '',
+  images_size: ''
+})
 const systemInfo = ref<SystemInfo>({
   app_version: '',
   php_version: '',
@@ -214,7 +229,6 @@ const systemInfo = ref<SystemInfo>({
     favorite_lists: 0,
     videos: 0,
     video_parts: 0,
-    danmaku: 0,
     db_size: 0
   },
   media_usage:{
@@ -241,15 +255,18 @@ const copyToClipboard = async (text: string) => {
   }
 }
 
-onMounted(async () => {
-  try {
-    const res = await getSystemInfo()
-    systemInfo.value = res
-  } catch (error) {
-    console.error('获取系统信息失败:', error)
-  } finally {
-    loading.value = false
-  }
+onMounted(() => {
+  // 系统信息（即时返回）
+  getSystemInfo()
+    .then((res) => { systemInfo.value = res })
+    .catch((error) => { console.error('获取系统信息失败:', error) })
+    .finally(() => { loading.value = false })
+
+  // 媒体占用（du -sh 较慢，异步加载）
+  fetchMediaUsage()
+    .then((res) => { mediaUsage.value = res })
+    .catch((error) => { console.error('获取媒体占用失败:', error) })
+    .finally(() => { mediaLoading.value = false })
 })
 </script>
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -26,6 +26,7 @@ Route::apiResource('/subscription', SubscriptionController::class)->only(['index
 
 // 显示系统校准信息
 Route::get('/system/info', [SystemController::class, 'getSystemInfo']);
+Route::get('/system/media-usage', [SystemController::class, 'getMediaUsage']);
 
 // 下载队列管理
 Route::get('/download-queue', [DownloadQueueController::class, 'index']);


### PR DESCRIPTION
## 问题背景

打开 `/about` 页面时，系统信息区域一直转圈，随后整个应用卡死。

两个慢查询叠加导致：
1. `Danmaku::count()` — `SELECT COUNT(*) FROM danmaku`，SQLite 没有行数缓存机制，千万级表（对于上万视频的情况来说，弹幕数量会非常夸张）需全表扫描，耗时极长，期间会锁住数据库（即使 WAL 模式下写操作也会被阻塞），导致整个应用卡死。
2. `du -sh` — 递归遍历 videos/images 目录统计大小，大量文件时首次调用需要数秒（OS 文件系统缓存未命中）

## 改动内容

- 移除 `Danmaku::count()` 调用，关于页面不再显示弹幕总数（此查询效率极其低下，会阻塞整个应用，并且意义不大）。
- 将媒体目录大小计算（`du -sh`）拆分为独立接口 `/api/system/media-usage`，前端异步加载，页面即时展示其他系统信息，媒体占用部分显示加载动画
- 修复 `getDatabaseSize()` 使用 `filesize()` 直接读取 SQLite 文件大小，替代不准确的 `sqlite_master` 查询（原本getDatabaseSize() 的 sum('rootpage') 查 sqlite_master 并不是获取数据库大小的正确方式）

## 改动文件

| 文件 | 改动说明 |
|------|---------|
| `app/Services/SystemService.php` | 移除 `Danmaku::count()`；媒体计算拆为 `getMediaUsage()`；修复 `getDatabaseSize()` |
| `app/Http/Controllers/SystemController.php` | 新增 `getMediaUsage()` 方法 |
| `routes/api.php` | 新增 `GET /api/system/media-usage` 路由 |
| `resources/js/api/system.ts` | 新增 `getMediaUsage()` API 调用 |
| `resources/js/pages/About.vue` | 移除弹幕统计；媒体占用改为异步加载，未完成时显示加载动画 |

## 已测试通过

- [x] 打开 `/about` 页面，页面瞬间加载，系统信息（版本、数据库统计等）立即显示
- [x] 媒体占用部分先显示转圈动画，计算完成后正常显示大小
- [x] 弹幕统计行不再显示
- [x] 数据库大小显示为正确的文件大小值